### PR TITLE
Fixes #11: Add logic to determine winner for existing games

### DIFF
--- a/codeclash/constants.py
+++ b/codeclash/constants.py
@@ -2,3 +2,4 @@ from pathlib import Path
 
 DIR_LOGS = Path("logs")
 DIR_WORK = Path("/testbed")
+RESULT_TIE = "Tie"

--- a/codeclash/games/battlesnake/main.py
+++ b/codeclash/games/battlesnake/main.py
@@ -1,4 +1,4 @@
-import re
+import json
 import time
 from typing import Any
 
@@ -19,34 +19,33 @@ class BattleSnakeGame(CodeGame):
             else:
                 self.run_cmd_round += f" --{arg} {val}"
 
-    def execute_round(self, agents: list[Any]):
-        cmd = self.run_cmd_round
+    def determine_winner(self, agents: list[Any]):
+        response = self.container.execute(f"tail -1 {self.round_log_path}")
+        winner = json.loads(response["output"].strip("\n"))["winnerName"]
+        self.scoreboard.append((self.round, winner))
 
+    def execute_round(self, agents: list[Any]):
+        cmd = []
         for idx, agent in enumerate(agents):
             port = 8001 + idx
             # Start server in background - just add & to run in background!
             self.container.execute(
                 f"PORT={port} python main.py &", cwd=f"/{agent.name}"
             )
-            cmd += f" --url http://0.0.0.0:{port} -n {agent.name}"
+            cmd.append(f"--url http://0.0.0.0:{port} -n {agent.name}")
 
         time.sleep(3)  # Give servers time to start
 
-        cmd += f" -o {self.round_log_path}"
+        cmd.append(f"-o {self.round_log_path}")
+        cmd = " ".join(cmd)
         print(f"Running command: {cmd}")
 
         try:
-            result = self.container.execute(
-                cmd,
+            response = self.container.execute(
+                f"{self.run_cmd_round} {cmd}",
                 cwd=f"{self.container.config.cwd}/game",
             )
-            assert result["returncode"] == 0
-            winner = re.search(r"\.\s(.*)\swas\sthe\swinner\.", result["output"]).group(
-                1
-            )
-            self.scoreboard.append((self.round, winner))
+            assert response["returncode"] == 0
         finally:
             # Kill all python servers when done
             self.container.execute("pkill -f 'python main.py' || true")
-
-        print(f"Round {self.round} completed.")

--- a/codeclash/games/corewar/main.py
+++ b/codeclash/games/corewar/main.py
@@ -1,5 +1,6 @@
+import re
+
 from codeclash.games.abstract import CodeGame
-from codeclash.games.utils import copy_between_containers
 
 
 class CoreWarGame(CodeGame):
@@ -16,11 +17,20 @@ class CoreWarGame(CodeGame):
             else:
                 self.run_cmd_round += f" -{arg} {val}"
 
-    def run_round(self, agents: list[any]):
-        cmd = self.run_cmd_round
+    def determine_winner(self, agents: list[any]):
+        scores = []
+        n = len(agents) * 2
+        response = self.container.execute(f"tail -{n} {self.round_log_path}")
+        for line in response["output"].splitlines():
+            match = re.search(r".*\sby\s.*\sscores\s(\d+)", line)
+            if match:
+                scores.append(int(match.group(1)))
+        winner = agents[scores.index(max(scores))].name
+        self.scoreboard.append((self.round, winner))
 
+    def execute_round(self, agents: list[any]):
         args = [f"/{agent.name}/warriors/warrior.red" for agent in agents]
         cmd = f"{self.run_cmd_round} {' '.join(args)} > {self.round_log_path}"
         print(f"Running command: {cmd}")
-        self.container.execute(cmd)
-        print(f"Round {self.round} completed.")
+        response = self.container.execute(cmd)
+        assert response["returncode"] == 0

--- a/codeclash/games/robotrumble/main.py
+++ b/codeclash/games/robotrumble/main.py
@@ -1,5 +1,5 @@
+from codeclash.constants import RESULT_TIE
 from codeclash.games.abstract import CodeGame
-from codeclash.games.utils import copy_between_containers
 
 
 class RobotRumbleGame(CodeGame):
@@ -10,12 +10,18 @@ class RobotRumbleGame(CodeGame):
         super().__init__(config)
         self.run_cmd_round: str = "./rumblebot run term"
 
-    def run_round(self, agents: list[any]):
-        super().run_round(agents)
-        cmd = self.run_cmd_round
+    def determine_winner(self, agents: list[any]):
+        response = self.container.execute(f"tail -2 {self.round_log_path}")
+        if "Blue won" in response["output"]:
+            self.scoreboard.append((self.round, agents[0].name))
+        elif "Red won" in response["output"]:
+            self.scoreboard.append((self.round, agents[1].name))
+        elif "it was a tie" in response["output"]:
+            self.scoreboard.append((self.round, RESULT_TIE))
 
+    def execute_round(self, agents: list[any]):
         args = [f"/{agent.name}/robot.py" for agent in agents]
         cmd = f"{self.run_cmd_round} {' '.join(args)} > {self.round_log_path}"
         print(f"Running command: {cmd}")
-        self.container.execute(cmd)
-        print(f"Round {self.round} completed.")
+        response = self.container.execute(cmd)
+        assert response["returncode"] == 0

--- a/configs/robocode.yaml
+++ b/configs/robocode.yaml
@@ -12,7 +12,7 @@ game:
       width: 800
       height: 600
   args:
-    nodisplay: false
+    nodisplay: true
     nosound: true
 players:
 - agent: dummy

--- a/main.py
+++ b/main.py
@@ -24,9 +24,7 @@ def main(config_path: str, cleanup: bool = False):
                 # TODO: Parallelize this in the future
                 agent.step(recap)
     finally:
-        game.end()
-        if cleanup:
-            game.cleanup()
+        game.end(cleanup)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add logic to determine which player won each round for the existing 4 games.

Right now, `CodeGame` just maintains a simple `scoreboard: list[tuple[int, str]]` field, where the first value corresponds to the round number, and the second value corresponds to the name of the agent that won (`agent.name`)

We could make this more complex in the future, such as determining who came in 2nd, 3rd... but for now this should be fine.