### PR TITLE
Document SCML and CybORG smoke checks

### DIFF
--- a/docs/reference/arenas/cyborg.md
+++ b/docs/reference/arenas/cyborg.md
@@ -71,4 +71,43 @@ The runtime pins CybORG to the upstream `v3.0` code and installs it editable fro
 repository because the upstream package expects data files such as `CybORG/version.txt` to be present
 next to the source tree.
 
+## Smoke Test
+
+From the repository root, run the dummy-player example:
+
+```bash
+uv run python main.py configs/examples/CybORG__dummy__r1__s2.yaml -o /tmp/codeclash-cyborg-smoke
+```
+
+Use a fresh `-o` directory when rerunning the smoke check.
+
+Expected shape:
+
+- the command exits with status 0;
+- both players pass submission validation;
+- stdout includes `In round 0, the winner is ...` and `In round 1, the winner is ...`;
+- each round summary contains floating-point average rewards for `alpha` and `beta`;
+- per-episode details have `status: "ok"` and `steps_completed: 5`;
+- the output directory contains `metadata.json`, `game.log`, `tournament.log`, and
+  `rounds/round_0.tar.gz` / `rounds/round_1.tar.gz`.
+
+A representative `metadata.json` round contains a `scores` object with one floating-point episode
+reward per player:
+
+```json
+"scores": {
+  "alpha": -27.0,
+  "beta": -33.5
+}
+```
+
+Exact values can change with simulator randomness and configuration; the smoke check is meant to
+verify the Docker/runtime adapter path, player-name mapping, and score/log artifact shape.
+
+The exact tournament directory name includes a timestamp, so inspect the metadata with:
+
+```bash
+find /tmp/codeclash-cyborg-smoke -maxdepth 3 -name metadata.json -print
+```
+
 --8<-- "docs/_footer.md"

--- a/docs/reference/arenas/scml.md
+++ b/docs/reference/arenas/scml.md
@@ -66,4 +66,42 @@ across those worlds.
 The runner rotates player ordering across simulations to reduce positional bias from factory
 assignment.
 
+## Smoke Test
+
+From the repository root, run the dummy-player example:
+
+```bash
+uv run python main.py configs/examples/SCML__dummy__r1__s2.yaml -o /tmp/codeclash-scml-smoke
+```
+
+Use a fresh `-o` directory when rerunning the smoke check.
+
+Expected shape:
+
+- the command exits with status 0;
+- both players pass submission validation;
+- stdout includes `In round 0, the winner is ...` and `In round 1, the winner is ...`;
+- each round summary contains floating-point average scores for `alpha` and `beta`;
+- the output directory contains `metadata.json`, `game.log`, `tournament.log`, and
+  `rounds/round_0.tar.gz` / `rounds/round_1.tar.gz`.
+
+A representative `metadata.json` round contains a `scores` object with one floating-point SCML
+profit score per player:
+
+```json
+"scores": {
+  "alpha": 1.0447501220885806,
+  "beta": 0.9783875910335903
+}
+```
+
+Exact values can change with simulation order and configuration; the smoke check is meant to verify
+the Docker/runtime adapter path, player-name mapping, and score/log artifact shape.
+
+The exact tournament directory name includes a timestamp, so inspect the metadata with:
+
+```bash
+find /tmp/codeclash-scml-smoke -maxdepth 3 -name metadata.json -print
+```
+
 --8<-- "docs/_footer.md"


### PR DESCRIPTION
## Summary
- Adds a reviewer-facing smoke-test section to the SCML arena docs with the exact dummy-player command, expected log/metadata artifacts, and expected score object shape.
- Adds the same smoke-test section to the CybORG arena docs, including the per-episode `status: "ok"` / `steps_completed` detail shape.
- Clarifies that the embedded score snippets are representative metadata examples, not stable golden values, because simulation order/configuration and CybORG randomness can change exact dummy scores.

## Why
This makes the newly merged SCML and CybORG arenas easier to sanity-check after pulling `main`: a reviewer can run one command per arena and verify validation, player-name mapping, scoring, and log artifact generation without reading the runtime code first.

## Verification
- `uv run python main.py configs/examples/SCML__dummy__r1__s2.yaml -o /tmp/codeclash-scml-smoke`
  - passed; both players validated; round summaries produced floating-point `alpha` / `beta` scores and metadata/log artifacts.
- `uv run python main.py configs/examples/CybORG__dummy__r1__s2.yaml -o /tmp/codeclash-cyborg-smoke`
  - passed; both players validated; per-episode details had `status: "ok"` and `steps_completed: 5`; metadata/log artifacts were written.
- `uv run pre-commit run --files docs/reference/arenas/scml.md docs/reference/arenas/cyborg.md`
- `uv run mkdocs build`
- `git diff --check`

## Notes
- This is docs-only; no runtime/config behavior changes.
- The docs tell reviewers to use a fresh `-o` directory when rerunning smoke checks instead of deleting output directories.