### PR TITLE
Scope markdown link checks on PRs

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -2,16 +2,29 @@ name: Check Markdown links
 
 on:
   workflow_dispatch:
-  push:
   pull_request:
   schedule:
     - cron: "0 0 1 * *"
 
 jobs:
-  markdown-link-check:
+  markdown-link-check-pr:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: '.github/mlc_config.json'
+          check-modified-files-only: 'yes'
+          base-branch: 'main'
+
+  markdown-link-check-full:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           config-file: '.github/mlc_config.json'


### PR DESCRIPTION
## Summary
- scope markdown link checks on pull requests to modified files only
- keep full-repository link checks for scheduled/manual runs
- switch checkout from `actions/checkout@master` to `actions/checkout@v4`

## Why
The current workflow scans every Markdown file on every PR. That means unrelated stale external links can block arena/code PRs even when the PR did not touch docs. PRs should fail for links they introduce or modify; repo-wide link rot is still useful, but it belongs in the scheduled/manual full scan.

This keeps fast PR feedback while preserving a periodic full-repo audit.

## Verification
- Parsed `.github/workflows/check-links.yaml` with PyYAML and asserted both job guards.
