### PR TITLE
Restrict CybORG player protocol

### DIFF
--- a/codeclash/arenas/cyborg/cyborg.py
+++ b/codeclash/arenas/cyborg/cyborg.py
@@ -8,6 +8,7 @@ from codeclash.constants import RESULT_TIE
 from codeclash.utils.environment import assert_zero_exit_code
 
 RESULTS_JSON = "cyborg_results.json"
+CRASH_SCORE = -1_000_000.0
 
 
 class CybORGArena(CodeArena):
@@ -15,27 +16,28 @@ class CybORGArena(CodeArena):
     submission: str = "cyborg_agent.py"
     description: str = """CybORG is a simulated cyber-defense arena based on the CAGE Challenge 3 DroneSwarm scenario.
 
-Your bot is a Python file named `cyborg_agent.py` that defines a class named `MyAgent`.
-`MyAgent` should inherit from a CybORG BaseAgent-compatible class, for example:
+Your bot is a Python file named `cyborg_agent.py` that defines a function named `decide`.
+The function receives a plain observation list and action-space dictionary, then returns an action:
 
-    from CybORG.Agents import RandomAgent
-
-    class MyAgent(RandomAgent):
-        ...
+    def decide(observation, action_space):
+        return 0
 
 Each round evaluates every submitted agent independently on the same seeded DroneSwarm episodes.
-Your agent controls the blue-team drone agents through CybORG's simulated PettingZoo interface.
-The objective is to maximize average episode reward. This arena uses CybORG simulation only and does
-    not run real exploit tools or interact with external networks.
-    """
+The trusted runtime owns the CybORG environment and action validation. Submitted code only receives
+plain observations and returns action intents. The objective is to maximize average episode reward.
+This arena uses CybORG simulation only and does not run real exploit tools or interact with external
+networks.
+"""
     default_args: dict = {
         "steps_per_episode": 30,
         "num_drones": 18,
+        "decision_timeout": 3.0,
+        "validation_timeout": 10,
         "timeout": 240,
     }
 
     def _game_arg(self, key: str):
-        return self.game_config.get("args", {}).get(key, self.default_args[key])
+        return getattr(self, "game_config", {}).get("args", {}).get(key, self.default_args[key])
 
     def _episodes_per_round(self) -> int:
         return int(self.game_config.get("args", {}).get("episodes_per_round", self.game_config["sims_per_round"]))
@@ -54,33 +56,25 @@ The objective is to maximize average episode reward. This arena uses CybORG simu
         if syntax_check["returncode"] != 0:
             return False, f"Python syntax error in `{self.submission}`:\n{syntax_check['output']}"
 
-        import_check = agent.environment.execute(
-            "python - <<'PY'\n"
-            "import importlib.util\n"
-            f"spec = importlib.util.spec_from_file_location('submission_agent', {self.submission!r})\n"
-            "module = importlib.util.module_from_spec(spec)\n"
-            "spec.loader.exec_module(module)\n"
-            "assert hasattr(module, 'MyAgent'), 'MyAgent class not found'\n"
-            "from CybORG.Agents import BaseAgent\n"
-            "assert issubclass(module.MyAgent, BaseAgent), 'MyAgent must inherit from a CybORG BaseAgent class'\n"
-            "def make_agent(agent_class, agent_name):\n"
-            "    try:\n"
-            "        return agent_class(name=agent_name)\n"
-            "    except TypeError:\n"
-            "        try:\n"
-            "            return agent_class(agent_name)\n"
-            "        except TypeError:\n"
-            "            try:\n"
-            "                return agent_class()\n"
-            "            except TypeError as final_error:\n"
-            "                raise TypeError(\n"
-            "                    'MyAgent could not be constructed with the CybORG runtime constructor fallbacks'\n"
-            "                ) from final_error\n"
-            "make_agent(module.MyAgent, 'validation-agent')\n"
-            "PY"
-        )
+        validation_timeout = int(self._game_arg("validation_timeout"))
+        try:
+            import_check = agent.environment.execute(
+                "python - <<'PY'\n"
+                "import importlib.util\n"
+                f"spec = importlib.util.spec_from_file_location('submission_agent', {self.submission!r})\n"
+                "module = importlib.util.module_from_spec(spec)\n"
+                "spec.loader.exec_module(module)\n"
+                "assert hasattr(module, 'decide'), 'decide function not found'\n"
+                "assert callable(module.decide), 'decide must be callable'\n"
+                "result = module.decide([0, 1, 0], {'type': 'discrete', 'n': 11})\n"
+                "assert result is None or isinstance(result, int), 'decide must return an integer action or None'\n"
+                "PY",
+                timeout=validation_timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"`decide` validation exceeded {validation_timeout}s timeout"
         if import_check["returncode"] != 0:
-            return False, f"Could not import `MyAgent` from `{self.submission}`:\n{import_check['output']}"
+            return False, f"Could not import or call `decide` from `{self.submission}`:\n{import_check['output']}"
 
         return True, None
 
@@ -98,6 +92,8 @@ The objective is to maximize average episode reward. This arena uses CybORG simu
             str(self._game_arg("steps_per_episode")),
             "--drones",
             str(self._game_arg("num_drones")),
+            "--decision-timeout",
+            str(self._game_arg("decision_timeout")),
             "--output",
             str(self.log_env / RESULTS_JSON),
             *agent_args,
@@ -116,8 +112,19 @@ The objective is to maximize average episode reward. This arena uses CybORG simu
             self.logger.error(f"Missing result file: {result_file}")
             stats.winner = RESULT_TIE
             for agent in agents:
-                stats.scores[agent.name] = 0.0
-                stats.player_stats[agent.name].score = 0.0
+                stats.scores[agent.name] = CRASH_SCORE
+                stats.player_stats[agent.name].score = CRASH_SCORE
+                stats.details.append(
+                    json.dumps(
+                        {
+                            "player": agent.name,
+                            "score": CRASH_SCORE,
+                            "status": "error",
+                            "error": f"missing CybORG result file: {result_file}",
+                        },
+                        sort_keys=True,
+                    )
+                )
             return
 
         with open(result_file) as f:

--- a/codeclash/arenas/cyborg/runtime/README.md
+++ b/codeclash/arenas/cyborg/runtime/README.md
@@ -2,14 +2,19 @@
 
 Edit `cyborg_agent.py`.
 
-Your file must define `MyAgent`, a CybORG `BaseAgent` subclass. A safe starting point is:
+Your file must define `decide(observation, action_space)`. The trusted runtime calls it with:
+
+- `observation`: a plain list converted from the CybORG observation array
+- `action_space`: a dictionary such as `{"type": "discrete", "n": 11}`
+
+Return an integer action in `[0, action_space["n"])`:
 
 ```python
-from CybORG.Agents import RandomAgent
-
-
-class MyAgent(RandomAgent):
-    pass
+def decide(observation, action_space):
+    return 0
 ```
 
-The arena runs simulated CAGE Challenge 3 DroneSwarm episodes and scores agents by average reward.
+The trusted CodeClash runtime owns the CybORG environment and validates returned actions before
+stepping the simulation. Submitted code only receives observations and returns action intents.
+
+The arena runs simulated CAGE Challenge 3 DroneSwarm episodes and scores policies by average reward.

--- a/codeclash/arenas/cyborg/runtime/cyborg_agent.py
+++ b/codeclash/arenas/cyborg/runtime/cyborg_agent.py
@@ -1,10 +1,3 @@
-from CybORG.Agents import RandomAgent
-
-
-class MyAgent(RandomAgent):
-    """Baseline CybORG blue-team agent.
-
-    Improve this class to choose better defensive actions in the simulated DroneSwarm scenario.
-    """
-
-    pass
+def decide(observation, action_space):
+    """Return a discrete CybORG action for the trusted runtime to validate."""
+    return 0

--- a/codeclash/arenas/cyborg/runtime/run_cyborg.py
+++ b/codeclash/arenas/cyborg/runtime/run_cyborg.py
@@ -1,19 +1,20 @@
 import argparse
+import contextlib
 import importlib.util
 import json
+import multiprocessing as mp
+import queue
 import random
 import re
+import sys
 import traceback
 from pathlib import Path
 from statistics import mean
 
 import numpy as np
-from CybORG import CybORG
-from CybORG.Agents import BaseAgent
-from CybORG.Agents.Wrappers.PettingZooParallelWrapper import PettingZooParallelWrapper
-from CybORG.Simulator.Scenarios import DroneSwarmScenarioGenerator
 
 CRASH_SCORE = -1_000_000.0
+DEFAULT_ACTION = 0
 
 
 def safe_module_name(player_name: str) -> str:
@@ -23,57 +24,200 @@ def safe_module_name(player_name: str) -> str:
     return f"codeclash_cyborg_{safe.lower()}"
 
 
-def load_agent_class(player_name: str, path: str):
+def load_policy_module(player_name: str, path: str):
+    agent_dir = str(Path(path).resolve().parent)
+    sys.path.insert(0, agent_dir)
     spec = importlib.util.spec_from_file_location(safe_module_name(player_name), path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Could not load module spec from {path}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    if not hasattr(module, "MyAgent"):
-        raise RuntimeError(f"{path} does not define MyAgent")
-    agent_class = module.MyAgent
-    if not issubclass(agent_class, BaseAgent):
-        raise RuntimeError(f"{path} MyAgent must inherit from CybORG BaseAgent")
-    return agent_class
-
-
-def make_agent(agent_class: type, agent_name: str):
     try:
-        return agent_class(name=agent_name)
-    except TypeError:
+        spec.loader.exec_module(module)
+    finally:
+        with contextlib.suppress(ValueError):
+            sys.path.remove(agent_dir)
+    if not hasattr(module, "decide") or not callable(module.decide):
+        raise RuntimeError(f"{path} must define a callable decide(observation, action_space)")
+    return module
+
+
+def observation_to_plain(observation):
+    if hasattr(observation, "tolist"):
+        return observation.tolist()
+    if isinstance(observation, dict):
+        return {str(key): observation_to_plain(value) for key, value in observation.items()}
+    if isinstance(observation, (list, tuple)):
+        return [observation_to_plain(value) for value in observation]
+    if isinstance(observation, np.generic):
+        return observation.item()
+    return observation
+
+
+def action_space_to_plain(action_space) -> dict:
+    n = getattr(action_space, "n", None)
+    if n is not None:
+        return {"type": "discrete", "n": int(n)}
+    return {"type": type(action_space).__name__}
+
+
+def normalize_action(action, action_space) -> tuple[int, str | None]:
+    n = getattr(action_space, "n", None)
+    if action is None:
+        return DEFAULT_ACTION, None
+    if isinstance(action, np.generic):
+        action = action.item()
+    if not isinstance(action, int):
+        return DEFAULT_ACTION, "action must be an integer"
+    if n is not None and not 0 <= action < int(n):
+        return DEFAULT_ACTION, f"action {action} outside Discrete({int(n)})"
+    return action, None
+
+
+def policy_worker(
+    command_queue: mp.Queue, result_queue: mp.Queue, player_name: str, agent_name: str, path: str
+) -> None:
+    try:
+        module = load_policy_module(player_name, path)
+    except BaseException as exc:
+        result_queue.put(
+            {
+                "request_id": None,
+                "error": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(limit=5),
+            }
+        )
+        return
+
+    while True:
         try:
-            return agent_class(agent_name)
-        except TypeError:
-            return agent_class()
+            request = command_queue.get()
+        except (EOFError, KeyboardInterrupt):
+            return
+        if request is None:
+            return
+        request_id = request["request_id"]
+        try:
+            action = module.decide(request["observation"], request["action_space"])
+            result_queue.put({"request_id": request_id, "action": action})
+        except BaseException as exc:
+            result_queue.put(
+                {
+                    "request_id": request_id,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "traceback": traceback.format_exc(limit=5),
+                }
+            )
+
+
+class PolicyController:
+    def __init__(self, player_name: str, agent_name: str, path: str, *, timeout: float):
+        self.player_name = player_name
+        self.agent_name = agent_name
+        self.path = path
+        self.timeout = max(float(timeout), 0.01)
+        self.errors: list[dict] = []
+        self.invalid_actions = 0
+        self.decisions = 0
+        self._next_request_id = 0
+        self._start_worker()
+
+    def _start_worker(self) -> None:
+        ctx = mp.get_context("spawn")
+        self.command_queue = ctx.Queue()
+        self.result_queue = ctx.Queue()
+        self.process = ctx.Process(
+            target=policy_worker,
+            args=(self.command_queue, self.result_queue, self.player_name, self.agent_name, self.path),
+        )
+        self.process.start()
+
+    def close(self) -> None:
+        with contextlib.suppress(Exception):
+            self.command_queue.put_nowait(None)
+        self.process.join(0.1)
+        if self.process.is_alive():
+            self.process.terminate()
+            self.process.join(0.1)
+        if self.process.is_alive():
+            self.process.kill()
+            self.process.join()
+
+    def restart(self) -> None:
+        self.close()
+        self._start_worker()
+
+    def decide(self, observation, action_space) -> int:
+        request_id = self._next_request_id
+        self._next_request_id += 1
+        self.command_queue.put(
+            {
+                "request_id": request_id,
+                "observation": observation_to_plain(observation),
+                "action_space": action_space_to_plain(action_space),
+            }
+        )
+        try:
+            result = self.result_queue.get(timeout=self.timeout)
+        except queue.Empty:
+            self.errors.append({"agent": self.agent_name, "error": f"decide exceeded {self.timeout}s timeout"})
+            self.restart()
+            return DEFAULT_ACTION
+
+        if result.get("request_id") not in {request_id, None}:
+            self.errors.append({"agent": self.agent_name, "error": "received stale policy result"})
+            return DEFAULT_ACTION
+        if "error" in result:
+            self.errors.append(
+                {
+                    "agent": self.agent_name,
+                    "error": result["error"],
+                    "traceback": result.get("traceback"),
+                }
+            )
+            if result.get("request_id") is None:
+                self.restart()
+            return DEFAULT_ACTION
+
+        action, error = normalize_action(result.get("action"), action_space)
+        if error is not None:
+            self.invalid_actions += 1
+            self.errors.append({"agent": self.agent_name, "error": error})
+        self.decisions += 1
+        return action
 
 
 def evaluate_player(
     player_name: str,
-    agent_class: type,
+    policy_path: str,
     *,
     episode_idx: int,
     steps: int,
     drones: int,
+    decision_timeout: float,
 ) -> dict:
     seed = 4100 + episode_idx
     random.seed(seed)
     np.random.seed(seed)
+    policies = {}
 
     try:
+        from CybORG import CybORG
+        from CybORG.Agents.Wrappers.PettingZooParallelWrapper import PettingZooParallelWrapper
+        from CybORG.Simulator.Scenarios import DroneSwarmScenarioGenerator
+
         scenario = DroneSwarmScenarioGenerator(num_drones=drones)
         env = PettingZooParallelWrapper(CybORG(scenario, "sim"))
         observations = env.reset()
         action_spaces = env.action_spaces
-        agents = {agent_name: make_agent(agent_class, agent_name) for agent_name in env.possible_agents}
-
-        for agent_name, agent in agents.items():
-            if hasattr(agent, "set_initial_values"):
-                agent.set_initial_values(action_spaces[agent_name], observations[agent_name])
+        policies = {
+            agent_name: PolicyController(player_name, agent_name, policy_path, timeout=decision_timeout)
+            for agent_name in env.possible_agents
+        }
 
         step_rewards = []
         for _ in range(steps):
             actions = {
-                agent_name: agents[agent_name].get_action(observations[agent_name], action_spaces[agent_name])
+                agent_name: policies[agent_name].decide(observations[agent_name], action_spaces[agent_name])
                 for agent_name in env.agents
             }
             observations, rewards, done, _info = env.step(actions)
@@ -81,15 +225,20 @@ def evaluate_player(
             if all(done.values()):
                 break
 
-        for agent in agents.values():
-            if hasattr(agent, "end_episode"):
-                agent.end_episode()
+        policy_errors = sum(len(policy.errors) for policy in policies.values())
+        invalid_actions = sum(policy.invalid_actions for policy in policies.values())
+        decisions = sum(policy.decisions for policy in policies.values())
+        error_samples = [error for policy in policies.values() for error in policy.errors[:2]][:5]
 
         return {
             "player": player_name,
             "episode": episode_idx,
             "score": float(sum(step_rewards)),
             "steps_completed": len(step_rewards),
+            "decisions": decisions,
+            "policy_errors": policy_errors,
+            "invalid_actions": invalid_actions,
+            "policy_error_samples": error_samples,
             "status": "ok",
         }
     except Exception as exc:
@@ -102,6 +251,9 @@ def evaluate_player(
             "error": f"{type(exc).__name__}: {exc}",
             "traceback": traceback.format_exc(limit=5),
         }
+    finally:
+        for policy in policies.values():
+            policy.close()
 
 
 def parse_agent_arg(value: str) -> tuple[str, str]:
@@ -121,21 +273,32 @@ def main() -> None:
     parser.add_argument("--episodes", type=int, default=3)
     parser.add_argument("--steps", type=int, default=30)
     parser.add_argument("--drones", type=int, default=18)
+    parser.add_argument("--decision-timeout", type=float, default=3.0)
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
 
-    agent_classes = {name: load_agent_class(name, path) for name, path in args.agent}
-    totals = {name: 0.0 for name in agent_classes}
+    if args.episodes < 1:
+        parser.error("--episodes must be at least 1")
+    if args.steps < 1:
+        parser.error("--steps must be at least 1")
+    if args.drones < 1:
+        parser.error("--drones must be at least 1")
+    if args.decision_timeout <= 0:
+        parser.error("--decision-timeout must be positive")
+
+    agent_paths = dict(args.agent)
+    totals = {name: 0.0 for name in agent_paths}
     details = []
 
     for episode_idx in range(args.episodes):
-        for player_name, agent_class in agent_classes.items():
+        for player_name, policy_path in agent_paths.items():
             result = evaluate_player(
                 player_name,
-                agent_class,
+                policy_path,
                 episode_idx=episode_idx,
                 steps=args.steps,
                 drones=args.drones,
+                decision_timeout=args.decision_timeout,
             )
             totals[player_name] += result["score"]
             details.append(result)

--- a/codeclash/arenas/cyborg/runtime/run_cyborg.py
+++ b/codeclash/arenas/cyborg/runtime/run_cyborg.py
@@ -26,7 +26,9 @@ def safe_module_name(player_name: str) -> str:
 
 def load_policy_module(player_name: str, path: str):
     agent_dir = str(Path(path).resolve().parent)
-    sys.path.insert(0, agent_dir)
+    inserted_agent_dir = agent_dir not in sys.path
+    if inserted_agent_dir:
+        sys.path.insert(0, agent_dir)
     spec = importlib.util.spec_from_file_location(safe_module_name(player_name), path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Could not load module spec from {path}")
@@ -34,7 +36,7 @@ def load_policy_module(player_name: str, path: str):
     try:
         spec.loader.exec_module(module)
     finally:
-        with contextlib.suppress(ValueError):
+        if inserted_agent_dir:
             sys.path.remove(agent_dir)
     if not hasattr(module, "decide") or not callable(module.decide):
         raise RuntimeError(f"{path} must define a callable decide(observation, action_space)")
@@ -74,19 +76,24 @@ def normalize_action(action, action_space) -> tuple[int, str | None]:
 
 
 def policy_worker(
-    command_queue: mp.Queue, result_queue: mp.Queue, player_name: str, agent_name: str, path: str
+    command_queue: mp.Queue,
+    result_queue: mp.Queue,
+    startup_queue: mp.Queue,
+    player_name: str,
+    agent_name: str,
+    path: str,
 ) -> None:
     try:
         module = load_policy_module(player_name, path)
     except BaseException as exc:
-        result_queue.put(
+        startup_queue.put(
             {
-                "request_id": None,
                 "error": f"{type(exc).__name__}: {exc}",
                 "traceback": traceback.format_exc(limit=5),
             }
         )
         return
+    startup_queue.put({"ready": True})
 
     while True:
         try:
@@ -118,18 +125,38 @@ class PolicyController:
         self.errors: list[dict] = []
         self.invalid_actions = 0
         self.decisions = 0
+        self.startup_error: str | None = None
         self._next_request_id = 0
         self._start_worker()
 
     def _start_worker(self) -> None:
+        self.startup_error = None
         ctx = mp.get_context("spawn")
         self.command_queue = ctx.Queue()
         self.result_queue = ctx.Queue()
+        self.startup_queue = ctx.Queue()
         self.process = ctx.Process(
             target=policy_worker,
-            args=(self.command_queue, self.result_queue, self.player_name, self.agent_name, self.path),
+            args=(
+                self.command_queue,
+                self.result_queue,
+                self.startup_queue,
+                self.player_name,
+                self.agent_name,
+                self.path,
+            ),
         )
         self.process.start()
+        startup_timeout = max(self.timeout, 10.0)
+        try:
+            startup_message = self.startup_queue.get(timeout=startup_timeout)
+        except queue.Empty:
+            self.startup_error = f"policy import exceeded {startup_timeout}s timeout"
+            self.close()
+            return
+        if "error" in startup_message:
+            self.startup_error = startup_message["error"]
+            self.close()
 
     def close(self) -> None:
         with contextlib.suppress(Exception):
@@ -147,6 +174,10 @@ class PolicyController:
         self._start_worker()
 
     def decide(self, observation, action_space) -> int:
+        if self.startup_error is not None:
+            self.errors.append({"agent": self.agent_name, "error": self.startup_error})
+            self.restart()
+            return DEFAULT_ACTION
         request_id = self._next_request_id
         self._next_request_id += 1
         self.command_queue.put(

--- a/configs/examples/CybORG__dummy__r1__s2.yaml
+++ b/configs/examples/CybORG__dummy__r1__s2.yaml
@@ -6,6 +6,8 @@ game:
   args:
     steps_per_episode: 5
     num_drones: 8
+    decision_timeout: 3.0
+    validation_timeout: 10
     timeout: 240
 players:
 - agent: dummy
@@ -23,11 +25,11 @@ prompts:
     Your task: improve `cyborg_agent.py`, located in {{working_dir}}.
     All commands run from {{working_dir}}.
 
-    Your file must define `MyAgent`, a CybORG BaseAgent subclass. A valid starting point is:
+    Your file must define `decide(observation, action_space)`. The trusted runtime passes a plain
+    observation list and an action-space dictionary such as `{"type": "discrete", "n": 11}`.
+    A valid starting point is:
 
-    from CybORG.Agents import RandomAgent
-
-    class MyAgent(RandomAgent):
-        pass
+    def decide(observation, action_space):
+        return 0
 
     The arena runs simulated DroneSwarm episodes. Your objective is to maximize average reward.

--- a/docs/reference/arenas/cyborg.md
+++ b/docs/reference/arenas/cyborg.md
@@ -9,8 +9,10 @@ The CodeClash arena uses CybORG's simulated DroneSwarm scenario through the Pett
 interface. It does not run real exploit tooling, emulate external networks, or interact with live
 systems.
 
-Each CodeClash player edits a blue-team CybORG agent. A round evaluates every submitted agent on the
-same seeded episode batch and scores players by average episode reward.
+Each CodeClash player edits a restricted blue-team policy. A round evaluates every submitted policy
+on the same seeded episode batch and scores players by average episode reward. The trusted runtime
+owns the CybORG environment and action validation; submitted code only receives plain observations
+and returns discrete action intents.
 
 ## Resources
 
@@ -26,21 +28,19 @@ same seeded episode batch and scores players by average episode reward.
 
 ## Agent Interface
 
-Your bot must be a Python file named `cyborg_agent.py` that defines `MyAgent`.
+Your bot must be a Python file named `cyborg_agent.py` that defines `decide(observation, action_space)`.
 
-`MyAgent` must inherit from a CybORG `BaseAgent` class. A valid starting point is:
+`observation` is a plain list converted from CybORG's observation array. `action_space` is a
+dictionary such as `{"type": "discrete", "n": 11}`. Return an integer action accepted by that
+action space. A valid starting point is:
 
 ```python
-from CybORG.Agents import RandomAgent
-
-
-class MyAgent(RandomAgent):
-    pass
+def decide(observation, action_space):
+    return 0
 ```
 
-The arena runs `MyAgent` through CybORG's PettingZoo parallel wrapper. For each episode, the same
-`MyAgent` class controls all blue-team drone agents. `get_action(observation, action_space)` should
-return an action accepted by the provided CybORG action space.
+For each episode, the same policy file controls all blue-team drone agents through isolated policy
+worker processes. The runtime validates every returned action before stepping the simulator.
 
 ## Configuration Example
 
@@ -53,6 +53,8 @@ game:
   args:
     steps_per_episode: 5
     num_drones: 8
+    decision_timeout: 3.0
+    validation_timeout: 10
     timeout: 240
 players:
   - agent: dummy
@@ -87,7 +89,8 @@ Expected shape:
 - both players pass submission validation;
 - stdout includes `In round 0, the winner is ...` and `In round 1, the winner is ...`;
 - each round summary contains floating-point average rewards for `alpha` and `beta`;
-- per-episode details have `status: "ok"` and `steps_completed: 5`;
+- per-episode details have `status: "ok"`, `steps_completed: 5`, `policy_errors`,
+  `invalid_actions`, and `decisions`;
 - the output directory contains `metadata.json`, `game.log`, `tournament.log`, and
   `rounds/round_0.tar.gz` / `rounds/round_1.tar.gz`.
 

--- a/tests/arenas/test_cyborg.py
+++ b/tests/arenas/test_cyborg.py
@@ -1,8 +1,9 @@
 import json
+import subprocess
 from pathlib import Path
 
 from codeclash.arenas.arena import RoundStats
-from codeclash.arenas.cyborg.cyborg import CybORGArena
+from codeclash.arenas.cyborg.cyborg import CRASH_SCORE, CybORGArena
 from codeclash.constants import RESULT_TIE
 
 from .conftest import MockEnvironment, MockPlayer
@@ -14,10 +15,13 @@ class TestCybORGValidation:
         arena.submission = "cyborg_agent.py"
         player = mock_player_factory(
             name="Alice",
-            files={"cyborg_agent.py": "class MyAgent:\n    pass\n"},
+            files={"cyborg_agent.py": "def decide(observation, action_space):\n    return 0\n"},
             command_outputs={
                 "test -f cyborg_agent.py && echo exists": {"output": "exists\n", "returncode": 0},
-                "cat cyborg_agent.py": {"output": "class MyAgent:\n    pass\n", "returncode": 0},
+                "cat cyborg_agent.py": {
+                    "output": "def decide(observation, action_space):\n    return 0\n",
+                    "returncode": 0,
+                },
                 "python -m py_compile cyborg_agent.py": {"output": "", "returncode": 0},
                 "python - <<'PY'": {"output": "", "returncode": 0},
             },
@@ -28,7 +32,7 @@ class TestCybORGValidation:
         assert valid is True
         assert error is None
 
-    def test_missing_myagent(self, mock_player_factory):
+    def test_missing_decide(self, mock_player_factory):
         arena = CybORGArena.__new__(CybORGArena)
         arena.submission = "cyborg_agent.py"
         player = mock_player_factory(
@@ -38,7 +42,7 @@ class TestCybORGValidation:
                 "test -f cyborg_agent.py && echo exists": {"output": "exists\n", "returncode": 0},
                 "cat cyborg_agent.py": {"output": "class OtherAgent:\n    pass\n", "returncode": 0},
                 "python -m py_compile cyborg_agent.py": {"output": "", "returncode": 0},
-                "python - <<'PY'": {"output": "MyAgent class not found", "returncode": 1},
+                "python - <<'PY'": {"output": "decide function not found", "returncode": 1},
             },
         )
 
@@ -52,10 +56,13 @@ class TestCybORGValidation:
         arena.submission = "cyborg_agent.py"
         player = mock_player_factory(
             name="Alice",
-            files={"cyborg_agent.py": "class MyAgent:\n    pass\n"},
+            files={"cyborg_agent.py": "def decide(observation, action_space):\n    raise ImportError('boom')\n"},
             command_outputs={
                 "test -f cyborg_agent.py && echo exists": {"output": "exists\n", "returncode": 0},
-                "cat cyborg_agent.py": {"output": "class MyAgent:\n    pass\n", "returncode": 0},
+                "cat cyborg_agent.py": {
+                    "output": "def decide(observation, action_space):\n    raise ImportError('boom')\n",
+                    "returncode": 0,
+                },
                 "python -m py_compile cyborg_agent.py": {"output": "", "returncode": 0},
                 "python - <<'PY'": {"output": "ImportError", "returncode": 1},
             },
@@ -66,16 +73,16 @@ class TestCybORGValidation:
         assert valid is False
         assert "Could not import" in error
 
-    def test_validation_instantiates_agent_with_runtime_fallbacks(self, mock_player_factory):
+    def test_validation_calls_decide_with_plain_protocol(self, mock_player_factory):
         arena = CybORGArena.__new__(CybORGArena)
         arena.submission = "cyborg_agent.py"
         player = mock_player_factory(
             name="Alice",
-            files={"cyborg_agent.py": "from CybORG.Agents import RandomAgent\nclass MyAgent(RandomAgent):\n    pass\n"},
+            files={"cyborg_agent.py": "def decide(observation, action_space):\n    return 0\n"},
             command_outputs={
                 "test -f cyborg_agent.py && echo exists": {"output": "exists\n", "returncode": 0},
                 "cat cyborg_agent.py": {
-                    "output": "from CybORG.Agents import RandomAgent\nclass MyAgent(RandomAgent):\n    pass\n",
+                    "output": "def decide(observation, action_space):\n    return 0\n",
                     "returncode": 0,
                 },
                 "python -m py_compile cyborg_agent.py": {"output": "", "returncode": 0},
@@ -87,35 +94,24 @@ class TestCybORGValidation:
         import_command = player.environment._executed_commands[-1]
         assert valid is True
         assert error is None
-        assert "make_agent(module.MyAgent, 'validation-agent')" in import_command
+        assert "module.decide([0, 1, 0], {'type': 'discrete', 'n': 11})" in import_command
+        assert "BaseAgent" not in import_command
 
-    def test_validation_rejects_agent_constructor_failure(self, mock_player_factory):
+    def test_validation_rejects_bad_decide_return_type(self, mock_player_factory):
         arena = CybORGArena.__new__(CybORGArena)
         arena.submission = "cyborg_agent.py"
         player = mock_player_factory(
             name="Alice",
-            files={
-                "cyborg_agent.py": (
-                    "from CybORG.Agents import RandomAgent\n"
-                    "class MyAgent(RandomAgent):\n"
-                    "    def __init__(self, seed=None):\n"
-                    "        super().__init__(seed=seed)\n"
-                )
-            },
+            files={"cyborg_agent.py": "def decide(observation, action_space):\n    return 'bad'\n"},
             command_outputs={
                 "test -f cyborg_agent.py && echo exists": {"output": "exists\n", "returncode": 0},
                 "cat cyborg_agent.py": {
-                    "output": (
-                        "from CybORG.Agents import RandomAgent\n"
-                        "class MyAgent(RandomAgent):\n"
-                        "    def __init__(self, seed=None):\n"
-                        "        super().__init__(seed=seed)\n"
-                    ),
+                    "output": "def decide(observation, action_space):\n    return 'bad'\n",
                     "returncode": 0,
                 },
                 "python -m py_compile cyborg_agent.py": {"output": "", "returncode": 0},
                 "python - <<'PY'": {
-                    "output": "TypeError: RandomAgent.__init__() got an unexpected keyword argument 'seed'",
+                    "output": "decide must return an integer action or None",
                     "returncode": 1,
                 },
             },
@@ -124,8 +120,27 @@ class TestCybORGValidation:
         valid, error = arena.validate_code(player)
 
         assert valid is False
-        assert "Could not import `MyAgent`" in error
-        assert "unexpected keyword argument 'seed'" in error
+        assert "Could not import or call `decide`" in error
+        assert "integer action" in error
+
+    def test_validation_rejects_decide_timeout(self):
+        class TimeoutEnvironment(MockEnvironment):
+            def execute(self, cmd: str, cwd: str | None = None, timeout: int | None = None):
+                if cmd.startswith("python - <<'PY'"):
+                    raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+                return super().execute(cmd, cwd=cwd, timeout=timeout)
+
+        arena = CybORGArena.__new__(CybORGArena)
+        arena.submission = "cyborg_agent.py"
+        player = MockPlayer(
+            "Alice",
+            TimeoutEnvironment(files={"cyborg_agent.py": "def decide(observation, action_space):\n    return 0\n"}),
+        )
+
+        valid, error = arena.validate_code(player)
+
+        assert valid is False
+        assert "`decide` validation exceeded 10s timeout" in error
 
 
 class TestCybORGResults:
@@ -181,6 +196,7 @@ class TestCybORGExecution:
                 "args": {
                     "steps_per_episode": 11,
                     "num_drones": 13,
+                    "decision_timeout": 2.5,
                     "timeout": 17,
                 },
             }
@@ -206,6 +222,7 @@ class TestCybORGExecution:
         assert "--episodes 5" in cmd
         assert "--steps 11" in cmd
         assert "--drones 13" in cmd
+        assert "--decision-timeout 2.5" in cmd
         assert "--output /logs/cyborg_results.json" in cmd
         assert "--agent Alice=/Alice/cyborg_agent.py" in cmd
         assert "--agent Bob=/Bob/cyborg_agent.py" in cmd
@@ -228,3 +245,20 @@ class TestCybORGExecution:
         arena.execute_round([MockPlayer("Alice")])
 
         assert "--episodes 7" in arena.environment._executed_commands[0]
+
+    def test_missing_results_file_penalizes_all_players(self, tmp_log_dir):
+        arena = CybORGArena.__new__(CybORGArena)
+        arena.log_local = tmp_log_dir
+        arena.logger = type("Logger", (), {"error": lambda self, msg: None})()
+
+        agents = [MockPlayer("Alice"), MockPlayer("Bob")]
+        stats = RoundStats(round_num=1, agents=agents)
+
+        arena.get_results(agents, 1, stats)
+
+        assert stats.winner == RESULT_TIE
+        assert stats.scores == {"Alice": CRASH_SCORE, "Bob": CRASH_SCORE}
+        assert stats.player_stats["Alice"].score == CRASH_SCORE
+        assert stats.player_stats["Bob"].score == CRASH_SCORE
+        assert len(stats.details) == 2
+        assert "missing CybORG result file" in stats.details[0]


### PR DESCRIPTION
## Summary
- replace the CybORG native `BaseAgent` submission surface with a restricted `decide(observation, action_space)` policy function
- keep the trusted runtime in charge of the CybORG/PettingZoo environment, action validation, scoring, and result-file handling
- run submitted policies in isolated per-agent worker processes with startup handshakes, per-decision timeouts, restart-on-timeout behavior, invalid-action clamping, and error details
- add validation timeouts, crash-score handling for missing result files, updated starter/docs/config, and tests for the restricted protocol

## Design Choice For Review
This intentionally makes CybORG more CodeClash-controlled than a native simulator-agent submission.

Instead of letting submitted code instantiate or mutate CybORG `BaseAgent` objects directly, the arena exposes only a plain policy callback:

```python
def decide(observation, action_space):
    return 0
```

The tradeoff is deliberate:
- pro: simulator ownership, scoring, validation, and timeouts stay in trusted arena code
- pro: submitted code is easier to isolate and failures degrade into logged fallback/default actions instead of corrupting the run
- con: policies cannot use the full native CybORG agent API directly

@john-b-yang could you sanity-check whether this restricted policy interface is the right CodeClash-compatible shape for CybORG, or whether you would rather expose native CybORG agent classes for more expressivity?

## Verification
- `uv run ruff check codeclash/arenas/cyborg/cyborg.py codeclash/arenas/cyborg/runtime/run_cyborg.py tests/arenas/test_cyborg.py`
- `uv run pytest -q tests/arenas/test_cyborg.py` -> 11 passed
- `uv run pytest -q tests/arenas` -> 187 passed
- `uv run pre-commit run --files codeclash/arenas/cyborg/cyborg.py codeclash/arenas/cyborg/runtime/README.md codeclash/arenas/cyborg/runtime/cyborg_agent.py codeclash/arenas/cyborg/runtime/run_cyborg.py configs/examples/CybORG__dummy__r1__s2.yaml docs/reference/arenas/cyborg.md tests/arenas/test_cyborg.py`
- `docker build -t codeclash/cyborg -f codeclash/arenas/cyborg/CybORG.Dockerfile .`
- direct Docker adversarial smoke with invalid-action, infinite-loop, and passive policies: invalid actions were clamped/logged; looping policy timed out per decision; runtime completed and wrote scores
- `uv run python main.py configs/examples/CybORG__dummy__r1__s2.yaml -o /private/tmp/codeclash-cyborg-final.e3pfFk` -> two launcher rounds completed, both players validated, all details had `status: "ok"`, `steps_completed: 5`, `policy_errors: 0`
- after adding worker startup handshakes: rebuilt `codeclash/cyborg` and reran `configs/examples/CybORG__dummy__r1__s2.yaml`; both launcher rounds completed with `policy_errors_total: 0` and `invalid_actions_total: 0`
- `uv run pytest -q` -> 189 passed
