### PR TITLE
Restrict SCML player protocol

### DIFF
--- a/codeclash/arenas/scml/runtime/README.md
+++ b/codeclash/arenas/scml/runtime/README.md
@@ -2,14 +2,16 @@
 
 Edit `scml_agent.py`.
 
-Your file must define `MyAgent`, an SCML OneShot agent class. A safe starting point is:
+Your file must define `decide(observation)`. The trusted runtime calls it with plain dictionaries
+for SCML proposal and response events. Return `{}` or `None` to use the trusted greedy fallback.
 
 ```python
-from scml.oneshot.agents import GreedySyncAgent
-
-
-class MyAgent(GreedySyncAgent):
-    pass
+def decide(observation):
+    return {}
 ```
 
-The arena runs multiple SCML2024 OneShot worlds and scores agents by average profit.
+For `event == "propose"`, return `{"offer": [quantity, time, unit_price]}` to make a proposal.
+For `event == "respond"`, return `{"response": "accept"}`, `{"response": "reject"}`, or
+`{"response": "end"}`. Invalid decisions fall back to the trusted greedy policy.
+
+The arena runs multiple two-process SCML2024 OneShot worlds and scores policies by average profit.

--- a/codeclash/arenas/scml/runtime/run_scml.py
+++ b/codeclash/arenas/scml/runtime/run_scml.py
@@ -35,7 +35,9 @@ def safe_module_name(player_name: str) -> str:
 
 def load_policy_module(player_name: str, path: str):
     agent_dir = str(Path(path).resolve().parent)
-    sys.path.insert(0, agent_dir)
+    inserted_agent_dir = agent_dir not in sys.path
+    if inserted_agent_dir:
+        sys.path.insert(0, agent_dir)
     module_name = f"codeclash_scml_{safe_class_name(player_name).lower()}"
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:
@@ -44,7 +46,7 @@ def load_policy_module(player_name: str, path: str):
     try:
         spec.loader.exec_module(module)
     finally:
-        with contextlib.suppress(ValueError):
+        if inserted_agent_dir:
             sys.path.remove(agent_dir)
     if not hasattr(module, "decide") or not callable(module.decide):
         raise RuntimeError(f"{path} must define a callable decide(observation)")
@@ -178,18 +180,20 @@ def normalize_response(response) -> tuple[ResponseType | None, str | None]:
     return None, f"unknown response: {response}"
 
 
-def policy_worker(command_queue: mp.Queue, result_queue: mp.Queue, player_name: str, path: str) -> None:
+def policy_worker(
+    command_queue: mp.Queue, result_queue: mp.Queue, startup_queue: mp.Queue, player_name: str, path: str
+) -> None:
     try:
         module = load_policy_module(player_name, path)
     except BaseException as exc:
-        result_queue.put(
+        startup_queue.put(
             {
-                "request_id": None,
                 "error": f"{type(exc).__name__}: {exc}",
                 "traceback": traceback.format_exc(limit=5),
             }
         )
         return
+    startup_queue.put({"ready": True})
 
     while True:
         try:
@@ -223,17 +227,31 @@ class PolicyController:
         self.policy_errors = 0
         self.invalid_decisions = 0
         self.error_samples: list[dict[str, str]] = []
+        self.startup_error: str | None = None
         self._next_request_id = 0
         self._start_worker()
 
     def _start_worker(self) -> None:
+        self.startup_error = None
         ctx = mp.get_context("spawn")
         self.command_queue = ctx.Queue()
         self.result_queue = ctx.Queue()
+        self.startup_queue = ctx.Queue()
         self.process = ctx.Process(
-            target=policy_worker, args=(self.command_queue, self.result_queue, self.player_name, self.path)
+            target=policy_worker,
+            args=(self.command_queue, self.result_queue, self.startup_queue, self.player_name, self.path),
         )
         self.process.start()
+        startup_timeout = max(self.timeout, 10.0)
+        try:
+            startup_message = self.startup_queue.get(timeout=startup_timeout)
+        except queue.Empty:
+            self.startup_error = f"policy import exceeded {startup_timeout}s timeout"
+            self.close()
+            return
+        if "error" in startup_message:
+            self.startup_error = startup_message["error"]
+            self.close()
 
     def _record_error(self, event: str, error: str, *, invalid: bool = False) -> None:
         self.policy_errors += 1
@@ -264,6 +282,11 @@ class PolicyController:
         if self.disabled:
             return {}
         event = str(observation.get("event", "unknown"))
+        if self.startup_error is not None:
+            self._record_error(event, self.startup_error)
+            if not self.disabled:
+                self.restart()
+            return {}
         request_id = self._next_request_id
         self._next_request_id += 1
         self.command_queue.put({"request_id": request_id, "observation": observation})

--- a/codeclash/arenas/scml/runtime/run_scml.py
+++ b/codeclash/arenas/scml/runtime/run_scml.py
@@ -1,12 +1,25 @@
 import argparse
+import contextlib
 import importlib.util
 import json
+import multiprocessing as mp
+import queue
 import random
 import re
+import sys
+import traceback
 from pathlib import Path
+from typing import Any
 
 import numpy as np
+from negmas import ResponseType, SAOResponse
 from scml.oneshot import SCML2024OneShotWorld
+from scml.oneshot.agents import GreedySyncAgent
+
+CRASH_SCORE = -1_000_000.0
+QUANTITY = 0
+TIME = 1
+UNIT_PRICE = 2
 
 
 def safe_class_name(player_name: str) -> str:
@@ -16,17 +29,394 @@ def safe_class_name(player_name: str) -> str:
     return f"CodeClash_{safe}"
 
 
-def load_agent_class(player_name: str, path: str):
+def safe_module_name(player_name: str) -> str:
+    return f"codeclash_scml_{safe_class_name(player_name).lower()}"
+
+
+def load_policy_module(player_name: str, path: str):
+    agent_dir = str(Path(path).resolve().parent)
+    sys.path.insert(0, agent_dir)
     module_name = f"codeclash_scml_{safe_class_name(player_name).lower()}"
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Could not load module spec from {path}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    if not hasattr(module, "MyAgent"):
-        raise RuntimeError(f"{path} does not define MyAgent")
-    base_class = module.MyAgent
-    return type(safe_class_name(player_name), (base_class,), {"__module__": module.__name__})
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        with contextlib.suppress(ValueError):
+            sys.path.remove(agent_dir)
+    if not hasattr(module, "decide") or not callable(module.decide):
+        raise RuntimeError(f"{path} must define a callable decide(observation)")
+    return module
+
+
+def to_plain(value):
+    if isinstance(value, np.generic):
+        return value.item()
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    if isinstance(value, dict):
+        return {str(key): to_plain(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_plain(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return repr(value)
+
+
+def issue_to_plain(issue) -> dict[str, Any]:
+    return {
+        "name": str(getattr(issue, "name", "")),
+        "min": to_plain(getattr(issue, "min_value", None)),
+        "max": to_plain(getattr(issue, "max_value", None)),
+        "values": to_plain(getattr(issue, "values", None)),
+    }
+
+
+def state_to_plain(state) -> dict[str, Any]:
+    return {
+        "step": to_plain(getattr(state, "step", None)),
+        "relative_time": to_plain(getattr(state, "relative_time", None)),
+        "current_offer": offer_to_plain(getattr(state, "current_offer", None)),
+    }
+
+
+def offer_to_plain(offer):
+    if offer is None:
+        return None
+    return [to_plain(item) for item in offer]
+
+
+def response_to_name(response) -> str:
+    if response == ResponseType.ACCEPT_OFFER:
+        return "accept"
+    if response == ResponseType.REJECT_OFFER:
+        return "reject"
+    if response == ResponseType.END_NEGOTIATION:
+        return "end"
+    return str(response).lower()
+
+
+def awi_to_plain(agent) -> dict[str, Any]:
+    awi = agent.awi
+    fields = [
+        "current_step",
+        "n_steps",
+        "n_lines",
+        "max_n_lines",
+        "current_score",
+        "current_balance",
+        "current_inventory",
+        "current_exogenous_input_quantity",
+        "current_exogenous_input_price",
+        "current_exogenous_output_quantity",
+        "current_exogenous_output_price",
+        "current_disposal_cost",
+        "current_shortfall_penalty",
+        "my_input_product",
+        "my_output_product",
+        "is_first_level",
+        "is_middle_level",
+        "is_last_level",
+        "needed_sales",
+        "needed_supplies",
+        "my_suppliers",
+        "my_consumers",
+    ]
+    return {field: to_plain(getattr(awi, field, None)) for field in fields}
+
+
+def nmi_to_plain(nmi) -> dict[str, Any]:
+    if nmi is None:
+        return {}
+    return {
+        "annotation": to_plain(getattr(nmi, "annotation", {})),
+        "issues": [issue_to_plain(issue) for issue in getattr(nmi, "issues", [])],
+    }
+
+
+def normalize_offer(offer, nmi) -> tuple[tuple[int, int, int] | None, str | None]:
+    if offer is None:
+        return None, None
+    if not isinstance(offer, (list, tuple)) or len(offer) != 3:
+        return None, "offer must be a 3-item list: [quantity, time, unit_price]"
+    issues = getattr(nmi, "issues", None)
+    if issues is None or len(issues) < 3:
+        return None, "missing SCML issue ranges"
+    normalized = []
+    for idx, raw_value in enumerate(offer):
+        if isinstance(raw_value, np.generic):
+            raw_value = raw_value.item()
+        if not isinstance(raw_value, int):
+            return None, f"offer item {idx} must be an integer"
+        issue = issues[idx]
+        min_value = getattr(issue, "min_value", None)
+        max_value = getattr(issue, "max_value", None)
+        if min_value is not None and raw_value < int(min_value):
+            return None, f"offer item {idx} below minimum {int(min_value)}"
+        if max_value is not None and raw_value > int(max_value):
+            return None, f"offer item {idx} above maximum {int(max_value)}"
+        normalized.append(int(raw_value))
+    return (normalized[QUANTITY], normalized[TIME], normalized[UNIT_PRICE]), None
+
+
+def normalize_response(response) -> tuple[ResponseType | None, str | None]:
+    if response is None:
+        return None, None
+    if isinstance(response, ResponseType):
+        return response, None
+    if not isinstance(response, str):
+        return None, "response must be one of: accept, reject, end"
+    normalized = response.strip().lower().replace("_", " ")
+    if normalized in {"accept", "accept offer", "accept_offer"}:
+        return ResponseType.ACCEPT_OFFER, None
+    if normalized in {"reject", "reject offer", "reject_offer"}:
+        return ResponseType.REJECT_OFFER, None
+    if normalized in {"end", "end negotiation", "end_negotiation"}:
+        return ResponseType.END_NEGOTIATION, None
+    return None, f"unknown response: {response}"
+
+
+def policy_worker(command_queue: mp.Queue, result_queue: mp.Queue, player_name: str, path: str) -> None:
+    try:
+        module = load_policy_module(player_name, path)
+    except BaseException as exc:
+        result_queue.put(
+            {
+                "request_id": None,
+                "error": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(limit=5),
+            }
+        )
+        return
+
+    while True:
+        try:
+            request = command_queue.get()
+        except (EOFError, KeyboardInterrupt):
+            return
+        if request is None:
+            return
+        request_id = request["request_id"]
+        try:
+            decision = module.decide(request["observation"])
+            result_queue.put({"request_id": request_id, "decision": decision})
+        except BaseException as exc:
+            result_queue.put(
+                {
+                    "request_id": request_id,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "traceback": traceback.format_exc(limit=5),
+                }
+            )
+
+
+class PolicyController:
+    def __init__(self, player_name: str, path: str, *, timeout: float, max_errors: int):
+        self.player_name = player_name
+        self.path = path
+        self.timeout = max(float(timeout), 0.01)
+        self.max_errors = max(int(max_errors), 1)
+        self.disabled = False
+        self.decisions = 0
+        self.policy_errors = 0
+        self.invalid_decisions = 0
+        self.error_samples: list[dict[str, str]] = []
+        self._next_request_id = 0
+        self._start_worker()
+
+    def _start_worker(self) -> None:
+        ctx = mp.get_context("spawn")
+        self.command_queue = ctx.Queue()
+        self.result_queue = ctx.Queue()
+        self.process = ctx.Process(
+            target=policy_worker, args=(self.command_queue, self.result_queue, self.player_name, self.path)
+        )
+        self.process.start()
+
+    def _record_error(self, event: str, error: str, *, invalid: bool = False) -> None:
+        self.policy_errors += 1
+        if invalid:
+            self.invalid_decisions += 1
+        if len(self.error_samples) < 5:
+            self.error_samples.append({"event": event, "error": error})
+        if self.policy_errors >= self.max_errors:
+            self.disabled = True
+            self.close()
+
+    def close(self) -> None:
+        with contextlib.suppress(Exception):
+            self.command_queue.put_nowait(None)
+        self.process.join(0.1)
+        if self.process.is_alive():
+            self.process.terminate()
+            self.process.join(0.1)
+        if self.process.is_alive():
+            self.process.kill()
+            self.process.join()
+
+    def restart(self) -> None:
+        self.close()
+        self._start_worker()
+
+    def decide(self, observation: dict[str, Any]) -> dict[str, Any]:
+        if self.disabled:
+            return {}
+        event = str(observation.get("event", "unknown"))
+        request_id = self._next_request_id
+        self._next_request_id += 1
+        self.command_queue.put({"request_id": request_id, "observation": observation})
+        try:
+            result = self.result_queue.get(timeout=self.timeout)
+        except queue.Empty:
+            self._record_error(event, f"decide exceeded {self.timeout}s timeout")
+            if not self.disabled:
+                self.restart()
+            return {}
+
+        if result.get("request_id") not in {request_id, None}:
+            self._record_error(event, "received stale policy result")
+            return {}
+        if "error" in result:
+            self._record_error(event, result["error"])
+            if result.get("request_id") is None and not self.disabled:
+                self.restart()
+            return {}
+        decision = result.get("decision")
+        if decision is None:
+            self.decisions += 1
+            return {}
+        if not isinstance(decision, dict):
+            self._record_error(event, "decide must return a dictionary or None", invalid=True)
+            return {}
+        self.decisions += 1
+        return decision
+
+
+def build_agent_class(player_name: str, path: str, *, decision_timeout: float, max_policy_errors: int):
+    class CodeClashSCMLAgent(GreedySyncAgent):
+        _policy_controllers: list[PolicyController] = []
+
+        def init(self):
+            super().init()
+            self._codeclash_policy = PolicyController(
+                player_name, path, timeout=decision_timeout, max_errors=max_policy_errors
+            )
+            self.__class__._policy_controllers.append(self._codeclash_policy)
+
+        def _base_observation(self, event: str, negotiator_id: str | None = None, state=None) -> dict[str, Any]:
+            nmi = self.get_nmi(negotiator_id) if negotiator_id else None
+            return {
+                "event": event,
+                "player": player_name,
+                "awi": awi_to_plain(self),
+                "negotiator_id": negotiator_id,
+                "nmi": nmi_to_plain(nmi),
+                "state": state_to_plain(state) if state is not None else {},
+            }
+
+        def propose(self, negotiator_id, state):
+            fallback = super().propose(negotiator_id, state)
+            observation = self._base_observation("propose", negotiator_id, state)
+            observation["fallback_offer"] = offer_to_plain(fallback)
+            decision = self._codeclash_policy.decide(observation)
+            if "offer" not in decision:
+                return fallback
+            offer, error = normalize_offer(decision.get("offer"), self.get_nmi(negotiator_id))
+            if error is not None:
+                self._codeclash_policy._record_error("propose", error, invalid=True)
+                return fallback
+            return offer
+
+        def respond(self, negotiator_id, state, source=""):
+            fallback = super().respond(negotiator_id, state, source)
+            observation = self._base_observation("respond", negotiator_id, state)
+            observation["fallback_response"] = response_to_name(fallback)
+            decision = self._codeclash_policy.decide(observation)
+            if "response" not in decision:
+                return fallback
+            response, error = normalize_response(decision.get("response"))
+            if error is not None:
+                self._codeclash_policy._record_error("respond", error, invalid=True)
+                return fallback
+            return response
+
+        def first_proposals(self):
+            fallback_proposals = super().first_proposals()
+            proposals = {}
+            for negotiator_id, fallback in fallback_proposals.items():
+                observation = self._base_observation("propose", negotiator_id)
+                observation["fallback_offer"] = offer_to_plain(fallback)
+                decision = self._codeclash_policy.decide(observation)
+                if "offer" not in decision:
+                    proposals[negotiator_id] = fallback
+                    continue
+                offer, error = normalize_offer(decision.get("offer"), self.get_nmi(negotiator_id))
+                if error is not None:
+                    self._codeclash_policy._record_error("propose", error, invalid=True)
+                    proposals[negotiator_id] = fallback
+                    continue
+                proposals[negotiator_id] = offer
+            return proposals
+
+        def counter_all(self, offers, states) -> dict:
+            fallback_responses = super().counter_all(offers, states)
+            responses = {}
+            for negotiator_id, raw_fallback in fallback_responses.items():
+                fallback = raw_fallback or SAOResponse(ResponseType.END_NEGOTIATION, None)
+                state = states.get(negotiator_id)
+                observation = self._base_observation("respond", negotiator_id, state)
+                observation["current_offer"] = offer_to_plain(offers.get(negotiator_id))
+                observation["fallback_response"] = response_to_name(fallback.response)
+                observation["fallback_offer"] = offer_to_plain(fallback.outcome)
+                decision = self._codeclash_policy.decide(observation)
+                if not decision:
+                    responses[negotiator_id] = fallback
+                    continue
+
+                response, response_error = normalize_response(decision.get("response"))
+                if response_error is not None:
+                    self._codeclash_policy._record_error("respond", response_error, invalid=True)
+                    responses[negotiator_id] = fallback
+                    continue
+                if response is None:
+                    responses[negotiator_id] = fallback
+                    continue
+                if response in {ResponseType.ACCEPT_OFFER, ResponseType.END_NEGOTIATION}:
+                    responses[negotiator_id] = SAOResponse(response, None)
+                    continue
+
+                offer = decision.get("offer", fallback.outcome)
+                normalized_offer, offer_error = normalize_offer(offer, self.get_nmi(negotiator_id))
+                if offer_error is not None:
+                    self._codeclash_policy._record_error("respond", offer_error, invalid=True)
+                    responses[negotiator_id] = fallback
+                    continue
+                responses[negotiator_id] = SAOResponse(ResponseType.REJECT_OFFER, normalized_offer)
+            return responses
+
+    CodeClashSCMLAgent.__name__ = safe_class_name(player_name)
+    CodeClashSCMLAgent.__qualname__ = safe_class_name(player_name)
+    return CodeClashSCMLAgent
+
+
+def policy_stats(agent_class: type) -> dict[str, Any]:
+    controllers = getattr(agent_class, "_policy_controllers", [])
+    return {
+        "decisions": sum(controller.decisions for controller in controllers),
+        "policy_errors": sum(controller.policy_errors for controller in controllers),
+        "invalid_decisions": sum(controller.invalid_decisions for controller in controllers),
+        "disabled_policies": sum(1 for controller in controllers if controller.disabled),
+        "policy_error_samples": [sample for controller in controllers for sample in controller.error_samples[:2]][:5],
+    }
+
+
+def close_policies(agent_classes: dict[str, type]) -> None:
+    for agent_class in agent_classes.values():
+        for controller in getattr(agent_class, "_policy_controllers", []):
+            controller.close()
+        agent_class._policy_controllers = []
 
 
 def run_world(agent_classes: dict[str, type], *, sim_idx: int, steps: int, lines: int) -> dict:
@@ -37,45 +427,68 @@ def run_world(agent_classes: dict[str, type], *, sim_idx: int, steps: int, lines
     player_names = list(agent_classes.keys())
     offset = sim_idx % len(player_names)
     ordered_names = player_names[offset:] + player_names[:offset]
-    wrapped_classes = [agent_classes[name] for name in ordered_names]
+    wrapped_classes = [agent_classes[name] for name in ordered_names] + [agent_classes[name] for name in ordered_names]
+    agent_processes = [0 for _ in ordered_names] + [1 for _ in ordered_names]
     class_to_player = {cls.__name__: player for player, cls in agent_classes.items()}
 
-    config = SCML2024OneShotWorld.generate(
-        agent_types=wrapped_classes,
-        agent_processes=[0 for _ in wrapped_classes],
-        n_steps=steps,
-        n_processes=1,
-        n_lines=lines,
-        random_agent_types=False,
-    )
-    world = SCML2024OneShotWorld(
-        **config,
-        no_logs=True,
-        compact=True,
-        fast=True,
-        agent_name_reveals_type=True,
-        agent_name_reveals_position=True,
-    )
-    world.run()
+    try:
+        config = SCML2024OneShotWorld.generate(
+            agent_types=wrapped_classes,
+            agent_processes=agent_processes,
+            n_steps=steps,
+            n_processes=2,
+            n_agents_per_process=[len(ordered_names), len(ordered_names)],
+            n_lines=lines,
+            random_agent_types=False,
+        )
+        world = SCML2024OneShotWorld(
+            **config,
+            no_logs=True,
+            compact=True,
+            fast=True,
+            agent_name_reveals_type=True,
+            agent_name_reveals_position=True,
+        )
+        world.run()
 
-    raw_scores = world.scores()
-    player_scores = {player: 0.0 for player in player_names}
-    details = []
-    for agent_id, score in raw_scores.items():
-        world_agent = world.agents[agent_id]
-        player = class_to_player.get(world_agent.short_type_name)
-        if player is None:
-            continue
-        numeric_score = float(score)
-        player_scores[player] = numeric_score
-        details.append(
+        raw_scores = world.scores()
+        player_score_lists = {player: [] for player in player_names}
+        details = []
+        for agent_id, score in raw_scores.items():
+            world_agent = world.agents[agent_id]
+            player = class_to_player.get(world_agent.short_type_name)
+            if player is None:
+                continue
+            numeric_score = float(score)
+            player_score_lists[player].append(numeric_score)
+            details.append(
+                {
+                    "sim": sim_idx,
+                    "player": player,
+                    "world_agent_id": agent_id,
+                    "score": numeric_score,
+                    **policy_stats(agent_classes[player]),
+                }
+            )
+        player_scores = {
+            player: float(sum(scores) / len(scores)) if scores else 0.0 for player, scores in player_score_lists.items()
+        }
+    except Exception as exc:
+        player_scores = {player: CRASH_SCORE for player in player_names}
+        details = [
             {
                 "sim": sim_idx,
                 "player": player,
-                "world_agent_id": agent_id,
-                "score": numeric_score,
+                "score": CRASH_SCORE,
+                "status": "error",
+                "error": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(limit=5),
+                **policy_stats(agent_classes[player]),
             }
-        )
+            for player in player_names
+        ]
+    finally:
+        close_policies(agent_classes)
 
     return {"scores": player_scores, "details": details}
 
@@ -97,10 +510,28 @@ def main() -> None:
     parser.add_argument("--sims", type=int, default=3)
     parser.add_argument("--steps", type=int, default=10)
     parser.add_argument("--lines", type=int, default=2)
+    parser.add_argument("--decision-timeout", type=float, default=3.0)
+    parser.add_argument("--max-policy-errors", type=int, default=8)
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
 
-    agent_classes = {name: load_agent_class(name, path) for name, path in args.agent}
+    if args.sims < 1:
+        parser.error("--sims must be at least 1")
+    if args.steps < 1:
+        parser.error("--steps must be at least 1")
+    if args.lines < 1:
+        parser.error("--lines must be at least 1")
+    if args.decision_timeout <= 0:
+        parser.error("--decision-timeout must be positive")
+    if args.max_policy_errors < 1:
+        parser.error("--max-policy-errors must be at least 1")
+
+    agent_classes = {
+        name: build_agent_class(
+            name, path, decision_timeout=args.decision_timeout, max_policy_errors=args.max_policy_errors
+        )
+        for name, path in args.agent
+    }
     totals = {name: 0.0 for name in agent_classes}
     details = []
 

--- a/codeclash/arenas/scml/runtime/scml_agent.py
+++ b/codeclash/arenas/scml/runtime/scml_agent.py
@@ -1,10 +1,6 @@
-from scml.oneshot.agents import GreedySyncAgent
+def decide(observation):
+    """Return SCML negotiation intents for the trusted runtime to validate.
 
-
-class MyAgent(GreedySyncAgent):
-    """Baseline SCML OneShot agent.
-
-    Improve this class to negotiate better supply-chain contracts and maximize profit.
+    Return {} or None to use the trusted greedy fallback.
     """
-
-    pass
+    return {}

--- a/codeclash/arenas/scml/scml.py
+++ b/codeclash/arenas/scml/scml.py
@@ -8,6 +8,7 @@ from codeclash.constants import RESULT_TIE
 from codeclash.utils.environment import assert_zero_exit_code
 
 RESULTS_JSON = "scml_results.json"
+CRASH_SCORE = -1_000_000.0
 
 
 class SCMLOneShotArena(CodeArena):
@@ -15,27 +16,29 @@ class SCMLOneShotArena(CodeArena):
     submission: str = "scml_agent.py"
     description: str = """SCML OneShot is a supply-chain negotiation simulator based on the ANAC Supply Chain Management League.
 
-Your bot is a Python file named `scml_agent.py` that defines a class named `MyAgent`.
-`MyAgent` should inherit from an SCML OneShot agent class, for example:
+Your bot is a Python file named `scml_agent.py` that defines a function named `decide`.
+The trusted runtime owns the SCML agent object and passes plain decision observations to your code:
 
-    from scml.oneshot.agents import GreedySyncAgent
+    def decide(observation):
+        return {}
 
-    class MyAgent(GreedySyncAgent):
-        ...
-
-Each round runs several SCML2024 OneShot worlds. Your agent negotiates with the other submitted
-agents to buy or sell goods in a simulated supply chain. The objective is to maximize profit. The
-arena score is your average SCML score across all worlds in the round.
+Each round runs several two-process SCML2024 OneShot worlds. Your policy controls trusted SCML
+wrapper agents that negotiate with the other submitted policies to buy and sell goods in a simulated
+supply chain. The objective is to maximize profit. The arena score is your average SCML score across
+all worlds in the round.
 """
     default_args: dict = {
         "sims_per_round": 3,
         "n_steps": 10,
         "n_lines": 2,
+        "decision_timeout": 3.0,
+        "max_policy_errors": 8,
+        "validation_timeout": 10,
         "timeout": 180,
     }
 
     def _game_arg(self, key: str):
-        return self.game_config.get(key, self.default_args[key])
+        return getattr(self, "game_config", {}).get(key, self.default_args[key])
 
     def validate_code(self, agent: Player) -> tuple[bool, str | None]:
         quoted_submission = shlex.quote(self.submission)
@@ -51,19 +54,25 @@ arena score is your average SCML score across all worlds in the round.
         if syntax_check["returncode"] != 0:
             return False, f"Python syntax error in `{self.submission}`:\n{syntax_check['output']}"
 
-        import_check = agent.environment.execute(
-            "python - <<'PY'\n"
-            "import importlib.util\n"
-            f"spec = importlib.util.spec_from_file_location('submission_agent', {self.submission!r})\n"
-            "module = importlib.util.module_from_spec(spec)\n"
-            "spec.loader.exec_module(module)\n"
-            "assert hasattr(module, 'MyAgent'), 'MyAgent class not found'\n"
-            "from scml.oneshot.agent import OneShotAgent\n"
-            "assert issubclass(module.MyAgent, OneShotAgent), 'MyAgent must inherit from an SCML OneShotAgent class'\n"
-            "PY"
-        )
+        validation_timeout = int(self._game_arg("validation_timeout"))
+        try:
+            import_check = agent.environment.execute(
+                "python - <<'PY'\n"
+                "import importlib.util\n"
+                f"spec = importlib.util.spec_from_file_location('submission_agent', {self.submission!r})\n"
+                "module = importlib.util.module_from_spec(spec)\n"
+                "spec.loader.exec_module(module)\n"
+                "assert hasattr(module, 'decide'), 'decide function not found'\n"
+                "assert callable(module.decide), 'decide must be callable'\n"
+                "result = module.decide({'event': 'validate', 'awi': {}, 'state': {}, 'nmi': {}})\n"
+                "assert result is None or isinstance(result, dict), 'decide must return a dictionary or None'\n"
+                "PY",
+                timeout=validation_timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"`decide` validation exceeded {validation_timeout}s timeout"
         if import_check["returncode"] != 0:
-            return False, f"Could not import `MyAgent` from `{self.submission}`:\n{import_check['output']}"
+            return False, f"Could not import or call `decide` from `{self.submission}`:\n{import_check['output']}"
 
         return True, None
 
@@ -81,6 +90,10 @@ arena score is your average SCML score across all worlds in the round.
             str(self._game_arg("n_steps")),
             "--lines",
             str(self._game_arg("n_lines")),
+            "--decision-timeout",
+            str(self._game_arg("decision_timeout")),
+            "--max-policy-errors",
+            str(self._game_arg("max_policy_errors")),
             "--output",
             str(self.log_env / RESULTS_JSON),
             *agent_args,
@@ -99,8 +112,19 @@ arena score is your average SCML score across all worlds in the round.
             self.logger.error(f"Missing result file: {result_file}")
             stats.winner = RESULT_TIE
             for agent in agents:
-                stats.scores[agent.name] = 0.0
-                stats.player_stats[agent.name].score = 0.0
+                stats.scores[agent.name] = CRASH_SCORE
+                stats.player_stats[agent.name].score = CRASH_SCORE
+                stats.details.append(
+                    json.dumps(
+                        {
+                            "player": agent.name,
+                            "score": CRASH_SCORE,
+                            "status": "error",
+                            "error": f"missing SCML result file: {result_file}",
+                        },
+                        sort_keys=True,
+                    )
+                )
             return
 
         with open(result_file) as f:

--- a/configs/examples/SCML__dummy__r1__s2.yaml
+++ b/configs/examples/SCML__dummy__r1__s2.yaml
@@ -5,6 +5,9 @@ game:
   sims_per_round: 2
   n_steps: 5
   n_lines: 2
+  decision_timeout: 3.0
+  max_policy_errors: 8
+  validation_timeout: 10
   timeout: 240
 players:
 - agent: dummy
@@ -21,11 +24,14 @@ prompts:
     Your task: improve `scml_agent.py`, located in {{working_dir}}.
     All commands run from {{working_dir}}.
 
-    Your file must define `MyAgent`, an SCML OneShot agent class. A valid starting point is:
+    Your file must define `decide(observation)`. A valid starting point is:
 
-    from scml.oneshot.agents import GreedySyncAgent
+    def decide(observation):
+        return {}
 
-    class MyAgent(GreedySyncAgent):
-        pass
+    For proposal events, return {"offer": [quantity, time, unit_price]} to override the trusted
+    greedy fallback. For response events, return {"response": "accept"}, {"response": "reject"},
+    or {"response": "end"}.
 
-    The arena runs multiple SCML2024 OneShot worlds. Your objective is to maximize average profit.
+    The arena runs multiple two-process SCML2024 OneShot worlds. Your objective is to maximize
+    average profit.

--- a/docs/reference/arenas/scml.md
+++ b/docs/reference/arenas/scml.md
@@ -8,8 +8,10 @@ SCML simulates a supply chain in which autonomous factory-manager agents negotia
 and sell goods. The CodeClash arena uses the SCML2024 OneShot world because it focuses on negotiation
 and profit without requiring long-term production scheduling.
 
-Each CodeClash player edits an SCML OneShot agent. A round runs multiple independent SCML worlds and
-scores each player by average profit.
+Each CodeClash player edits a restricted SCML decision policy. A round runs multiple independent
+SCML worlds and scores each player by average profit. The trusted runtime owns the SCML agent object,
+world state, and validation; submitted code only receives plain observations and returns negotiation
+intents.
 
 ## Resources
 
@@ -25,20 +27,19 @@ scores each player by average profit.
 
 ## Agent Interface
 
-Your bot must be a Python file named `scml_agent.py` that defines `MyAgent`.
+Your bot must be a Python file named `scml_agent.py` that defines `decide(observation)`.
 
-`MyAgent` must inherit from an SCML OneShot agent class. A valid starting point is:
+Return `{}` or `None` to use the trusted greedy fallback. A valid starting point is:
 
 ```python
-from scml.oneshot.agents import GreedySyncAgent
-
-
-class MyAgent(GreedySyncAgent):
-    pass
+def decide(observation):
+    return {}
 ```
 
-Agents can use the normal SCML OneShot APIs exposed by the upstream `scml` package. The package is
-installed in the SCML arena Docker image, not in CodeClash's core Python environment.
+For proposal events, return `{"offer": [quantity, time, unit_price]}`. The runtime validates that
+the offer is inside SCML's current issue ranges before sending it to the simulator. For response
+events, return `{"response": "accept"}`, `{"response": "reject"}`, or `{"response": "end"}`.
+Invalid decisions fall back to the trusted greedy policy and are recorded in round details.
 
 ## Configuration Example
 
@@ -50,6 +51,10 @@ game:
   sims_per_round: 2
   n_steps: 5
   n_lines: 2
+  decision_timeout: 3.0
+  max_policy_errors: 8
+  validation_timeout: 10
+  timeout: 240
 players:
   - agent: dummy
     name: alpha
@@ -59,9 +64,11 @@ players:
 
 ## Scoring
 
-The arena runs `sims_per_round` independent SCML2024 OneShot worlds. For each world, it maps SCML
-agent scores back to CodeClash player names. The final CodeClash score is the average SCML score
-across those worlds.
+The arena runs `sims_per_round` independent SCML2024 OneShot worlds. Each world has two supply-chain
+process levels; every CodeClash player controls one trusted SCML wrapper agent at each level so the
+submitted policies participate in actual buy/sell negotiations. The final per-world player score is
+the mean SCML score across that player's controlled agents, and the final CodeClash score is the
+average across worlds.
 
 The runner rotates player ordering across simulations to reduce positional bias from factory
 assignment.
@@ -82,6 +89,8 @@ Expected shape:
 - both players pass submission validation;
 - stdout includes `In round 0, the winner is ...` and `In round 1, the winner is ...`;
 - each round summary contains floating-point average scores for `alpha` and `beta`;
+- per-simulation details include `decisions`, `policy_errors`, `invalid_decisions`,
+  `disabled_policies`, and `policy_error_samples`;
 - the output directory contains `metadata.json`, `game.log`, `tournament.log`, and
   `rounds/round_0.tar.gz` / `rounds/round_1.tar.gz`.
 
@@ -90,8 +99,8 @@ profit score per player:
 
 ```json
 "scores": {
-  "alpha": 1.0447501220885806,
-  "beta": 0.9783875910335903
+  "alpha": 0.6536304953204003,
+  "beta": 0.5384855419684607
 }
 ```
 

--- a/tests/arenas/test_scml.py
+++ b/tests/arenas/test_scml.py
@@ -1,10 +1,12 @@
 import json
+import subprocess
+from pathlib import Path
 
 from codeclash.arenas.arena import RoundStats
-from codeclash.arenas.scml.scml import SCMLOneShotArena
+from codeclash.arenas.scml.scml import CRASH_SCORE, SCMLOneShotArena
 from codeclash.constants import RESULT_TIE
 
-from .conftest import MockPlayer
+from .conftest import MockEnvironment, MockPlayer
 
 
 class TestSCMLValidation:
@@ -13,10 +15,10 @@ class TestSCMLValidation:
         arena.submission = "scml_agent.py"
         player = mock_player_factory(
             name="Alice",
-            files={"scml_agent.py": "class MyAgent:\n    pass\n"},
+            files={"scml_agent.py": "def decide(observation):\n    return {}\n"},
             command_outputs={
                 "test -f scml_agent.py && echo exists": {"output": "exists\n", "returncode": 0},
-                "cat scml_agent.py": {"output": "class MyAgent:\n    pass\n", "returncode": 0},
+                "cat scml_agent.py": {"output": "def decide(observation):\n    return {}\n", "returncode": 0},
                 "python -m py_compile scml_agent.py": {"output": "", "returncode": 0},
                 "python - <<'PY'": {"output": "", "returncode": 0},
             },
@@ -27,7 +29,7 @@ class TestSCMLValidation:
         assert valid is True
         assert error is None
 
-    def test_missing_myagent(self, mock_player_factory):
+    def test_missing_decide(self, mock_player_factory):
         arena = SCMLOneShotArena.__new__(SCMLOneShotArena)
         arena.submission = "scml_agent.py"
         player = mock_player_factory(
@@ -37,7 +39,7 @@ class TestSCMLValidation:
                 "test -f scml_agent.py && echo exists": {"output": "exists\n", "returncode": 0},
                 "cat scml_agent.py": {"output": "class OtherAgent:\n    pass\n", "returncode": 0},
                 "python -m py_compile scml_agent.py": {"output": "", "returncode": 0},
-                "python - <<'PY'": {"output": "MyAgent class not found", "returncode": 1},
+                "python - <<'PY'": {"output": "decide function not found", "returncode": 1},
             },
         )
 
@@ -51,10 +53,13 @@ class TestSCMLValidation:
         arena.submission = "scml_agent.py"
         player = mock_player_factory(
             name="Alice",
-            files={"scml_agent.py": "class MyAgent:\n    pass\n"},
+            files={"scml_agent.py": "def decide(observation):\n    raise ImportError('boom')\n"},
             command_outputs={
                 "test -f scml_agent.py && echo exists": {"output": "exists\n", "returncode": 0},
-                "cat scml_agent.py": {"output": "class MyAgent:\n    pass\n", "returncode": 0},
+                "cat scml_agent.py": {
+                    "output": "def decide(observation):\n    raise ImportError('boom')\n",
+                    "returncode": 0,
+                },
                 "python -m py_compile scml_agent.py": {"output": "", "returncode": 0},
                 "python - <<'PY'": {"output": "ImportError", "returncode": 1},
             },
@@ -64,6 +69,67 @@ class TestSCMLValidation:
 
         assert valid is False
         assert "Could not import" in error
+
+    def test_validation_calls_decide_with_plain_protocol(self, mock_player_factory):
+        arena = SCMLOneShotArena.__new__(SCMLOneShotArena)
+        arena.submission = "scml_agent.py"
+        player = mock_player_factory(
+            name="Alice",
+            files={"scml_agent.py": "def decide(observation):\n    return {}\n"},
+            command_outputs={
+                "test -f scml_agent.py && echo exists": {"output": "exists\n", "returncode": 0},
+                "cat scml_agent.py": {"output": "def decide(observation):\n    return {}\n", "returncode": 0},
+                "python -m py_compile scml_agent.py": {"output": "", "returncode": 0},
+                "python - <<'PY'": {"output": "", "returncode": 0},
+            },
+        )
+
+        valid, error = arena.validate_code(player)
+
+        import_command = player.environment._executed_commands[-1]
+        assert valid is True
+        assert error is None
+        assert "module.decide({'event': 'validate', 'awi': {}, 'state': {}, 'nmi': {}})" in import_command
+        assert "OneShotAgent" not in import_command
+
+    def test_validation_rejects_bad_decide_return_type(self, mock_player_factory):
+        arena = SCMLOneShotArena.__new__(SCMLOneShotArena)
+        arena.submission = "scml_agent.py"
+        player = mock_player_factory(
+            name="Alice",
+            files={"scml_agent.py": "def decide(observation):\n    return 'bad'\n"},
+            command_outputs={
+                "test -f scml_agent.py && echo exists": {"output": "exists\n", "returncode": 0},
+                "cat scml_agent.py": {"output": "def decide(observation):\n    return 'bad'\n", "returncode": 0},
+                "python -m py_compile scml_agent.py": {"output": "", "returncode": 0},
+                "python - <<'PY'": {"output": "decide must return a dictionary or None", "returncode": 1},
+            },
+        )
+
+        valid, error = arena.validate_code(player)
+
+        assert valid is False
+        assert "Could not import or call `decide`" in error
+        assert "dictionary" in error
+
+    def test_validation_rejects_decide_timeout(self):
+        class TimeoutEnvironment(MockEnvironment):
+            def execute(self, cmd: str, cwd: str | None = None, timeout: int | None = None):
+                if cmd.startswith("python - <<'PY'"):
+                    raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+                return super().execute(cmd, cwd=cwd, timeout=timeout)
+
+        arena = SCMLOneShotArena.__new__(SCMLOneShotArena)
+        arena.submission = "scml_agent.py"
+        player = MockPlayer(
+            "Alice",
+            TimeoutEnvironment(files={"scml_agent.py": "def decide(observation):\n    return {}\n"}),
+        )
+
+        valid, error = arena.validate_code(player)
+
+        assert valid is False
+        assert "`decide` validation exceeded 10s timeout" in error
 
 
 class TestSCMLResults:
@@ -107,3 +173,52 @@ class TestSCMLResults:
 
         assert stats.winner == RESULT_TIE
         assert stats.scores == {"Alice": 1.0, "Bob": 1.0}
+
+    def test_missing_results_file_penalizes_all_players(self, tmp_log_dir):
+        arena = SCMLOneShotArena.__new__(SCMLOneShotArena)
+        arena.log_local = tmp_log_dir
+        arena.logger = type("Logger", (), {"error": lambda self, msg: None})()
+
+        agents = [MockPlayer("Alice"), MockPlayer("Bob")]
+        stats = RoundStats(round_num=1, agents=agents)
+
+        arena.get_results(agents, 1, stats)
+
+        assert stats.winner == RESULT_TIE
+        assert stats.scores == {"Alice": CRASH_SCORE, "Bob": CRASH_SCORE}
+        assert stats.player_stats["Alice"].score == CRASH_SCORE
+        assert stats.player_stats["Bob"].score == CRASH_SCORE
+        assert len(stats.details) == 2
+        assert "missing SCML result file" in stats.details[0]
+
+
+class TestSCMLExecution:
+    def test_execute_round_passes_restricted_protocol_args(self):
+        arena = SCMLOneShotArena.__new__(SCMLOneShotArena)
+        arena.submission = "scml_agent.py"
+        arena.log_env = Path("/logs")
+        arena.config = {
+            "game": {
+                "sims_per_round": 5,
+                "n_steps": 11,
+                "n_lines": 3,
+                "decision_timeout": 0.75,
+                "max_policy_errors": 4,
+                "timeout": 17,
+            }
+        }
+        arena.environment = MockEnvironment()
+        arena.logger = type("Logger", (), {"info": lambda self, msg: None})()
+
+        arena.execute_round([MockPlayer("Alice"), MockPlayer("Bob")])
+
+        cmd = arena.environment._executed_commands[0]
+        assert "python run_scml.py" in cmd
+        assert "--sims 5" in cmd
+        assert "--steps 11" in cmd
+        assert "--lines 3" in cmd
+        assert "--decision-timeout 0.75" in cmd
+        assert "--max-policy-errors 4" in cmd
+        assert "--output /logs/scml_results.json" in cmd
+        assert "--agent Alice=/Alice/scml_agent.py" in cmd
+        assert "--agent Bob=/Bob/scml_agent.py" in cmd


### PR DESCRIPTION
## Summary
- replace native SCML `OneShotAgent` submissions with a restricted `decide(observation)` policy function
- keep SCML world objects, trusted wrapper agents, offer/response validation, scoring, and result-file handling inside the arena runtime
- run submitted policies in isolated worker processes with startup handshakes, per-decision timeouts, and `max_policy_errors` fallback disabling
- switch SCML worlds to a two-process setup so submitted policies actually participate in buy/sell negotiations
- update starter code, docs, example config, validation, and tests for the restricted protocol

## Design Choice For Review
This intentionally makes SCML more CodeClash-controlled than a native simulator-agent submission.

Instead of letting submitted code subclass SCML `OneShotAgent` directly, the arena exposes only a plain policy callback:

```python
def decide(observation):
    return {}
```

The trusted runtime owns the actual SCML agents and converts policy decisions into validated negotiation intents:
- proposal: `{"offer": [quantity, time, unit_price]}`
- response: `{"response": "accept" | "reject" | "end"}`
- `{}` or `None`: use the trusted greedy fallback

The tradeoff is deliberate:
- pro: simulator ownership, scoring, offer validation, timeouts, and fallback behavior stay in trusted arena code
- pro: submitted code cannot directly mutate the scored SCML agent/world objects
- con: policies cannot use the full native SCML agent API directly, so this is less expressive than native `OneShotAgent` submissions

@john-b-yang could you sanity-check whether this restricted policy interface is the right CodeClash-compatible shape for SCML, or whether you would rather expose native SCML agent classes for more expressivity?

## Verification
- `uv run ruff check codeclash/arenas/scml/scml.py codeclash/arenas/scml/runtime/run_scml.py tests/arenas/test_scml.py`
- `uv run pytest -q tests/arenas/test_scml.py` -> 10 passed
- `uv run pytest -q tests/arenas` -> 190 passed
- `uv run pre-commit run --files codeclash/arenas/scml/scml.py codeclash/arenas/scml/runtime/README.md codeclash/arenas/scml/runtime/scml_agent.py codeclash/arenas/scml/runtime/run_scml.py configs/examples/SCML__dummy__r1__s2.yaml docs/reference/arenas/scml.md tests/arenas/test_scml.py`
- `docker build -t codeclash/scml -f codeclash/arenas/scml/SCML.Dockerfile .`
- direct Docker starter smoke: two sims completed; all details had nonzero `decisions`, zero `policy_errors`, zero `invalid_decisions`, and zero `disabled_policies`
- direct Docker invalid-output smoke: invalid offers/responses were rejected, logged as `invalid_decisions`, and the world completed using trusted fallback behavior
- direct Docker infinite-loop smoke: looping policies hit per-decision timeout, were disabled after `max_policy_errors`, and the world completed using trusted fallback behavior
- `uv run python main.py configs/examples/SCML__dummy__r1__s2.yaml -o /private/tmp/codeclash-scml-protocol.sFesGl` -> two launcher rounds completed, both players validated, details had active policy decisions and zero policy errors
- after adding worker startup handshakes: rebuilt `codeclash/scml` and reran `configs/examples/SCML__dummy__r1__s2.yaml`; both launcher rounds completed with `policy_errors_total: 0` and `invalid_decisions_total: 0`
- `uv run pytest -q` -> 192 passed
